### PR TITLE
Ignoring KarafIT until Pax Exam 4.14.0 is released

### DIFF
--- a/karaf/src/test/java/ca/islandora/alpaca/karaf/KarafIT.java
+++ b/karaf/src/test/java/ca/islandora/alpaca/karaf/KarafIT.java
@@ -43,6 +43,7 @@ import java.io.File;
 import javax.inject.Inject;
 
 import org.apache.karaf.features.FeaturesService;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -63,6 +64,7 @@ import org.slf4j.Logger;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
+@Ignore
 public class KarafIT {
 
     private static Logger LOGGER = getLogger(KarafIT.class);


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1443

https://groups.google.com/forum/#!topic/ops4j/pJ98QaBVPfE/discussion
https://ops4j1.jira.com/browse/PAXEXAM-934

# What does this Pull Request do?

Ignores the PaxExam test class. 

We need to wait for the 4.14.0 release to re-enable and correct the default maven central address.
Once it is released we can re-enable the test.

# How should this be tested?

Empty your maven repository (`~/.m2/repository` on Mac/Linux)
Build this PR and it passes

# Interested parties
@Islandora/8-x-committers - especially @elizoller 
