### PR TITLE
fixes to release Alpaca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bin/
 .bloop/
 .metals/
 islandora-alpaca-app/src/main/resources/alpaca.properties
+.java-version

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ allprojects  {
 
     release {
         tagTemplate = '$name-$version'
+        git {
+            requireBranch = '2.x'
+        }
     }
 
     afterReleaseBuild.dependsOn uploadArchives


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Changes the required branch from "master" to "2.x", so you can release from this branch as you can't fast-forward anymore.

An alternate is to set `requireBranch = ''` which makes it ignore it. That seemed more dangerous than just updating it once a major version.

Also ignores the `jenv` java version file on my machine.

# Additional Notes:

Due to upgrading the Gradle version and changes in its publishing and the weak `--dry-run` of this plugin, I might have to spend some time getting this to work.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
