### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/build-1.x.yml
+++ b/.github/workflows/build-1.x.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    braches: [1.x]
+    branches: [1.x]
   pull_request:
     branches: [1.x]
 


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

Branches has been misspelled in our Github actions and causes Github to use the default of `*` (all branches)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers, especially @alxp 
