### PR TITLE
Allow configuration of Camel Http options

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,24 @@ socket.timeout=-1
 
 The default for all three is `-1` which indicates no timeout.
 
+### Alter HTTP options
+
+By default, Alpaca uses two settings for the HTTP component, these are
+* disableStreamCache=true
+* connectionClose=true
+
+If you want to send additional [configuration parameters](https://camel.apache.org/components/3.18.x/http-component.html#_query_parameters) or alter the existing defaults. You can 
+add them as a comma separated list of key=value pairs.
+
+For example
+```shell
+http.additional_options=authMethod=Basic,authUsername=Jim,authPassword=1234
+```
+
+These will be added to ALL http endpoint requests.
+
+**Note**: We are currently running Camel 3.7.6, some configuration parameters on the above linked page might not be supported.
+
 ## Deploying/Running
 
 You can see the options by passing the `-h|--help` flag

--- a/example.properties
+++ b/example.properties
@@ -12,6 +12,9 @@ request.timeout=-1
 connection.timeout=-1
 socket.timeout=-1
 
+# Additional HTTP endpoint options, these can be for Camel or to be sent to the baseUrl or service.url
+http.additional_options=
+
 # Fedora indexer options
 fcrepo.indexer.enabled=true
 fcrepo.indexer.node=queue:islandora-indexing-fcrepo-content

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.1.0
+version = 2.2.0

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeOptions.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeOptions.java
@@ -64,8 +64,6 @@ public class DerivativeOptions extends PropertyConfig {
   /**
    * Register additional beans for derivative routes.
    *
-   * @param camelContext
-   *   The camel context to add derivative service routes to.
    * @throws Exception
    *   When unable to add routes to the camel context.
    */
@@ -90,8 +88,6 @@ public class DerivativeOptions extends PropertyConfig {
   /**
    * Attempt to start the routes and add them to the camel context.
    *
-   * @param camelContext
-   *   The current camel context.
    * @param serviceName
    *   The derivative service name.
    * @throws Exception

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest.java
@@ -28,35 +28,30 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.AdviceWith;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.ModelCamelContext;
-import org.apache.camel.spring.javaconfig.CamelConfiguration;
 import org.apache.camel.test.spring.UseAdviceWith;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import ca.islandora.alpaca.support.config.ActivemqConfig;
-
 /**
- * @author dannylamb
+ * Test of connector with the additional http options added.
  * @author whikloj
+ * @since 2.2.0
  */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @UseAdviceWith
 @ContextConfiguration(classes = DerivativeConnectorTest.ContextConfig.class,
         loader = AnnotationConfigContextLoader.class)
-@TestPropertySource("/test1.properties")
+@TestPropertySource("/test2.properties")
 @RunWith(SpringJUnit4ClassRunner.class)
-public class DerivativeConnectorTest {
+public class ConnectorWithHttpOptionsTest {
 
     private static final Logger LOGGER = getLogger(DerivativeConnectorTest.class);
 
@@ -67,16 +62,16 @@ public class DerivativeConnectorTest {
     CamelContext camelContext;
 
     @Test
-    public void testDerivativeConnector() throws Exception {
-        final String route = "IslandoraConnectorDerivative-testRoutes";
+    public void testDerivativeConnectorWithOptions() throws Exception {
+        final String route = "IslandoraConnectorDerivative-testRoutesWithOptions";
 
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, route, a -> {
             a.replaceFromWith("direct:start");
 
             // Rig Drupal REST endpoint to return canned jsonld
-            a.interceptSendToEndpoint("http://example.org/derivative/convert?connectionClose=true&" +
-                            "disableStreamCache=true")
+            a.interceptSendToEndpoint("http://example.org/derivative/other?connectionClose=true&" +
+                            "disableStreamCache=true&specialProp=true")
                     .skipSendToOriginalEndpoint()
                     .process(exchange -> {
                         exchange.getIn().removeHeaders("*", "Authorization");
@@ -85,7 +80,7 @@ public class DerivativeConnectorTest {
                     });
 
             a.mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?connectionClose=true&" +
-                    "disableStreamCache=true");
+                    "disableStreamCache=true&specialProp=true");
         });
         context.start();
 
@@ -104,13 +99,5 @@ public class DerivativeConnectorTest {
         });
 
         endpoint.assertIsSatisfied();
-    }
-
-    @Configuration
-    @ComponentScan(basePackageClasses = {DerivativeOptions.class, ActivemqConfig.class},
-            useDefaultFilters = false,
-            includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-                    classes = {DerivativeOptions.class, ActivemqConfig.class}))
-    static class ContextConfig extends CamelConfiguration {
     }
 }

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest2.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest2.java
@@ -70,8 +70,8 @@ public class ConnectorWithHttpOptionsTest2 {
             a.replaceFromWith("direct:start");
 
             // Rig Drupal REST endpoint to return canned jsonld
-            a.interceptSendToEndpoint("http://example.org/derivative/other?connectionClose=true&" +
-                            "disableStreamCache=true&specialProp=true&otherProp=91")
+            a.interceptSendToEndpoint("http://example.org/derivative/other?specialProp=true&otherProp=91" +
+                            "&connectionClose=true&disableStreamCache=true")
                     .skipSendToOriginalEndpoint()
                     .process(exchange -> {
                         exchange.getIn().removeHeaders("*", "Authorization");
@@ -79,8 +79,8 @@ public class ConnectorWithHttpOptionsTest2 {
                         exchange.getIn().setBody("SOME DERIVATIVE", String.class);
                     });
 
-            a.mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?connectionClose=true&" +
-                    "disableStreamCache=true&specialProp=true&otherProp=91");
+            a.mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?specialProp=true&otherProp=91" +
+                    "&connectionClose=true&disableStreamCache=true");
         });
         context.start();
 

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest2.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/ConnectorWithHttpOptionsTest2.java
@@ -28,35 +28,30 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.AdviceWith;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.model.ModelCamelContext;
-import org.apache.camel.spring.javaconfig.CamelConfiguration;
 import org.apache.camel.test.spring.UseAdviceWith;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-import ca.islandora.alpaca.support.config.ActivemqConfig;
-
 /**
- * @author dannylamb
+ * Test of connector with the additional http options added.
  * @author whikloj
+ * @since 2.2.0
  */
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @UseAdviceWith
 @ContextConfiguration(classes = DerivativeConnectorTest.ContextConfig.class,
         loader = AnnotationConfigContextLoader.class)
-@TestPropertySource("/test1.properties")
+@TestPropertySource("/test3.properties")
 @RunWith(SpringJUnit4ClassRunner.class)
-public class DerivativeConnectorTest {
+public class ConnectorWithHttpOptionsTest2 {
 
     private static final Logger LOGGER = getLogger(DerivativeConnectorTest.class);
 
@@ -67,16 +62,16 @@ public class DerivativeConnectorTest {
     CamelContext camelContext;
 
     @Test
-    public void testDerivativeConnector() throws Exception {
-        final String route = "IslandoraConnectorDerivative-testRoutes";
+    public void testDerivativeConnectorWithMultipleOptions() throws Exception {
+        final String route = "IslandoraConnectorDerivative-testRoutesWithMultipleOptions";
 
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, route, a -> {
             a.replaceFromWith("direct:start");
 
             // Rig Drupal REST endpoint to return canned jsonld
-            a.interceptSendToEndpoint("http://example.org/derivative/convert?connectionClose=true&" +
-                            "disableStreamCache=true")
+            a.interceptSendToEndpoint("http://example.org/derivative/other?connectionClose=true&" +
+                            "disableStreamCache=true&specialProp=true&otherProp=91")
                     .skipSendToOriginalEndpoint()
                     .process(exchange -> {
                         exchange.getIn().removeHeaders("*", "Authorization");
@@ -85,7 +80,7 @@ public class DerivativeConnectorTest {
                     });
 
             a.mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?connectionClose=true&" +
-                    "disableStreamCache=true");
+                    "disableStreamCache=true&specialProp=true&otherProp=91");
         });
         context.start();
 
@@ -104,13 +99,5 @@ public class DerivativeConnectorTest {
         });
 
         endpoint.assertIsSatisfied();
-    }
-
-    @Configuration
-    @ComponentScan(basePackageClasses = {DerivativeOptions.class, ActivemqConfig.class},
-            useDefaultFilters = false,
-            includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE,
-                    classes = {DerivativeOptions.class, ActivemqConfig.class}))
-    static class ContextConfig extends CamelConfiguration {
     }
 }

--- a/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/OverrideHttpOptionsTest.java
+++ b/islandora-connector-derivative/src/test/java/ca/islandora/alpaca/connector/derivative/OverrideHttpOptionsTest.java
@@ -41,7 +41,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 /**
- * Test of connector with the additional http options added.
+ * Test overriding one of the default options.
  * @author whikloj
  * @since 2.2.0
  */
@@ -49,9 +49,9 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 @UseAdviceWith
 @ContextConfiguration(classes = DerivativeConnectorTest.ContextConfig.class,
         loader = AnnotationConfigContextLoader.class)
-@TestPropertySource("/test2.properties")
+@TestPropertySource("/test-override.properties")
 @RunWith(SpringJUnit4ClassRunner.class)
-public class ConnectorWithHttpOptionsTest {
+public class OverrideHttpOptionsTest {
 
     private static final Logger LOGGER = getLogger(DerivativeConnectorTest.class);
 
@@ -62,16 +62,16 @@ public class ConnectorWithHttpOptionsTest {
     CamelContext camelContext;
 
     @Test
-    public void testDerivativeConnectorWithOptions() throws Exception {
-        final String route = "IslandoraConnectorDerivative-testRoutesWithOptions";
+    public void testDerivativeConnectorWithOverride() throws Exception {
+        final String route = "IslandoraConnectorDerivative-testRoutesWithOverride";
 
         final var context = camelContext.adapt(ModelCamelContext.class);
         AdviceWith.adviceWith(context, route, a -> {
             a.replaceFromWith("direct:start");
 
             // Rig Drupal REST endpoint to return canned jsonld
-            a.interceptSendToEndpoint("http://example.org/derivative/other?specialProp=true&connectionClose=true&" +
-                            "disableStreamCache=true")
+            a.interceptSendToEndpoint("http://example.org/derivative/other?specialProp=true&" +
+                            "disableStreamCache=false&connectionClose=true")
                     .skipSendToOriginalEndpoint()
                     .process(exchange -> {
                         exchange.getIn().removeHeaders("*", "Authorization");
@@ -80,7 +80,7 @@ public class ConnectorWithHttpOptionsTest {
                     });
 
             a.mockEndpointsAndSkip("http://localhost:8000/node/2/media/image/3?specialProp=true&" +
-                    "connectionClose=true&disableStreamCache=true");
+                    "disableStreamCache=false&connectionClose=true");
         });
         context.start();
 

--- a/islandora-connector-derivative/src/test/resources/test-override.properties
+++ b/islandora-connector-derivative/src/test/resources/test-override.properties
@@ -1,0 +1,6 @@
+derivative.systems.installed=testRoutesWithOverride
+derivative.testRoutesWithOverride.enabled=true
+derivative.testRoutesWithOverride.in.stream=topic:input
+derivative.testRoutesWithOverride.service.url=http://example.org/derivative/other
+error.maxRedeliveries=1
+http.additional_options=specialProp=true,disableStreamCache=false

--- a/islandora-connector-derivative/src/test/resources/test1.properties
+++ b/islandora-connector-derivative/src/test/resources/test1.properties
@@ -1,0 +1,5 @@
+derivative.systems.installed=testRoutes
+derivative.testRoutes.enabled=true
+derivative.testRoutes.in.stream=topic:input
+derivative.testRoutes.service.url=http://example.org/derivative/convert
+error.maxRedeliveries=1

--- a/islandora-connector-derivative/src/test/resources/test2.properties
+++ b/islandora-connector-derivative/src/test/resources/test2.properties
@@ -1,0 +1,6 @@
+derivative.systems.installed=testRoutesWithOptions
+derivative.testRoutesWithOptions.enabled=true
+derivative.testRoutesWithOptions.in.stream=topic:input
+derivative.testRoutesWithOptions.service.url=http://example.org/derivative/other
+error.maxRedeliveries=1
+http.additional_options=specialProp=true

--- a/islandora-connector-derivative/src/test/resources/test3.properties
+++ b/islandora-connector-derivative/src/test/resources/test3.properties
@@ -1,0 +1,6 @@
+derivative.systems.installed=testRoutesWithMultipleOptions
+derivative.testRoutesWithMultipleOptions.enabled=true
+derivative.testRoutesWithMultipleOptions.in.stream=topic:input
+derivative.testRoutesWithMultipleOptions.service.url=http://example.org/derivative/other
+error.maxRedeliveries=1
+http.additional_options=specialProp=true&otherProp=91

--- a/islandora-connector-derivative/src/test/resources/test3.properties
+++ b/islandora-connector-derivative/src/test/resources/test3.properties
@@ -3,4 +3,4 @@ derivative.testRoutesWithMultipleOptions.enabled=true
 derivative.testRoutesWithMultipleOptions.in.stream=topic:input
 derivative.testRoutesWithMultipleOptions.service.url=http://example.org/derivative/other
 error.maxRedeliveries=1
-http.additional_options=specialProp=true&otherProp=91
+http.additional_options=specialProp=true,otherProp=91

--- a/islandora-support/src/main/java/ca/islandora/alpaca/support/config/PropertyConfig.java
+++ b/islandora-support/src/main/java/ca/islandora/alpaca/support/config/PropertyConfig.java
@@ -41,15 +41,35 @@ public abstract class PropertyConfig {
   // static endpoint name for activemq connection
   protected static final String JMS_ENDPOINT_NAME = "broker";
   protected static final String MAX_REDELIVERIES_PROPERTY = "error.maxRedeliveries";
+  protected static final String ADDITIONAL_HTTP_OPTIONS = "http.additional_options";
 
   @Value("${" + MAX_REDELIVERIES_PROPERTY + ":5}")
   private int maxRedeliveries;
+
+  @Value("${" + ADDITIONAL_HTTP_OPTIONS + ":}")
+  private String additionalHttpOptions;
 
   /**
    * @return the error.maxRedeliveries amount.
    */
   public int getMaxRedeliveries() {
     return maxRedeliveries;
+  }
+
+  /**
+   * @return the additional http options with a preceding & if non-empty, otherwise blank string.
+   */
+  private String getAdditionalHttpOptions() {
+    final String returnOptions;
+    if (!additionalHttpOptions.isEmpty()) {
+      if (additionalHttpOptions.startsWith("&") || additionalHttpOptions.startsWith("?")) {
+        returnOptions = additionalHttpOptions.substring(1);
+      } else {
+        returnOptions = additionalHttpOptions;
+      }
+      return "&" + returnOptions;
+    }
+    return "";
   }
 
   /**
@@ -104,7 +124,7 @@ public abstract class PropertyConfig {
    *   The modified http endpoint string.
    */
   public String addHttpOptions(final String httpEndpoint, final boolean forceAmpersand) {
-    final String commonElements = "connectionClose=true&disableStreamCache=true";
+    final String commonElements = "connectionClose=true&disableStreamCache=true" + getAdditionalHttpOptions();
     final int bestGuessAtFinalLength = httpEndpoint.length() + commonElements.length() + 1;
     final StringBuilder builder = new StringBuilder(bestGuessAtFinalLength);
     builder.append(httpEndpoint);

--- a/islandora-support/src/main/java/ca/islandora/alpaca/support/config/PropertyConfig.java
+++ b/islandora-support/src/main/java/ca/islandora/alpaca/support/config/PropertyConfig.java
@@ -17,6 +17,9 @@
  */
 package ca.islandora.alpaca.support.config;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
@@ -32,6 +35,7 @@ import org.springframework.context.annotation.PropertySources;
 })
 public abstract class PropertyConfig {
 
+  private static final Logger LOGGER = getLogger(PropertyConfig.class);
   public static final String ALPACA_CONFIG_PROPERTY = "alpaca.config";
   public static final String ALPACA_HOME_PROPERTY = "alpaca.home";
   public static final String ALPACA_DEFAULT_HOME = "alpaca-home-directory";
@@ -109,6 +113,7 @@ public abstract class PropertyConfig {
         .append(asyncConsumers);
     }
     if (builder.length() > 0) {
+      LOGGER.trace("addJmsOptions returning builder {}", builder);
       return queueString + (queueString.contains("?") ? '&' : '?') + builder;
     }
     return queueString;
@@ -138,6 +143,7 @@ public abstract class PropertyConfig {
     }
     // Append the common elements.
     builder.append(commonElements);
+    LOGGER.trace("addHttpOptions returning {}", builder);
     return builder.toString();
   }
 

--- a/islandora-support/src/test/java/ca/islandora/alpaca/support/config/HttpConfigurerTest.java
+++ b/islandora-support/src/test/java/ca/islandora/alpaca/support/config/HttpConfigurerTest.java
@@ -56,7 +56,7 @@ public class HttpConfigurerTest {
     private CamelContext context;
 
     /**
-     * Insure that the default RequestConfig for the HttpComponent carries the timeout values specified in the
+     * Ensure that the default RequestConfig for the HttpComponent carries the timeout values specified in the
      * blueprint xml.
      *
      * Note that the RequestConfig and RequestConfigConfigurer are difficult to test with mocking frameworks such as


### PR DESCRIPTION
**GitHub Issue**: N/A

# What does this Pull Request do?

Adds a new configuration property that allows a user to add configuration properties to all camel http requests.

# What's new?

The new option (`http.additional_options`) takes a comma separated list of &lt;key&gt;=&lt;value&gt; pairs. 

It them splits them into a list and checks to see if the default parameters have been defined by the user. If not they are appended to the list. 

The whole list is joined with `&`s and then appended to the end of the URL using a `?` if there isn't one in the URL or a `&` if there already is a `?` found.

* Does this change require documentation to be updated? Updated
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

1. Pull down and build this 
     `./gradlew clean build shadowJar`
1. Replace your Alpaca jar with this one.
2. Turn your logging level to TRACE by adding the `-Dislandora.alpaca.log=TRACE` to the `java -jar` command
3. Use Islandora and check your logs for entries like
    ```
     TRACE 16:10:48.843 [main] (PropertyConfig) addHttpOptions returning http://127.0.0.1:8080/bigdata/namespace/islandora/sparql?connectionClose=true&disableStreamCache=true
     ```
4. Alter your properties file to add `http.additional_options=something=something`
5. Restart Alpaca and use Islandora some more
6. See the log entries now include your option
     ```
     TRACE 16:10:48.843 [main] (PropertyConfig) addHttpOptions returning http://127.0.0.1:8080/bigdata/namespace/islandora/sparql?something=something&connectionClose=true&disableStreamCache=true
     ```
7. Try altering a default, i.e. `http.additional_options=something=something,disableStreamCache=false`
8. Restart Alpaca and use Islandora some more
9. See the log entries include your option and also alter the default.
     ```
     TRACE 16:10:48.843 [main] (PropertyConfig) addHttpOptions returning http://127.0.0.1:8080/bigdata/namespace/islandora/sparql?something=something&disableStreamCache=false&connectionClose=true
     ```

# Interested parties
@Islandora/committers especially @seth-shaw-asu 
