### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ![Alpaca](https://cloud.githubusercontent.com/assets/2371345/15409648/16c140b4-1dec-11e6-81d9-41929bc83b1f.png) Alpaca
-[![Build Status](https://github.com/islandora/Alpaca/actions/workflows/build-1.x.yml/badge.svg)](https://github.com/Islandora/Alpaca/actions)
+[![Build Status](https://github.com/islandora/Alpaca/actions/workflows/build-2.x.yml/badge.svg)](https://github.com/Islandora/Alpaca/actions)
 [![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/Islandora/Alpaca/branch/1.x/graphs/badge.svg)](https://codecov.io/gh/Islandora/Alpaca)


### PR DESCRIPTION
Build badge was still pointing at the 1.x branch

**GitHub Issue**: n/a

# What does this Pull Request do?

Updates the CI build badge to show the correct state on the README

# What's new?

* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (i.e. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# How should this be tested?

Se the correct (read: passing) build badge on the Alpaca README

# Interested parties
@Islandora/committers
