### PR TITLE
Fix codecov and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@ A description of what steps someone could take to:
 Any additional information that you think would be helpful when reviewing this PR.
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @Islandora/8-x-committers
+Tag (@ mention) interested parties or, if unsure, @Islandora/committers

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,10 @@
 codecov:
   # Default branch for CodeCov information
-  branch: 1.x
+  branch: 2.x
 
 coverage:
   status:
     project:
       default:
         branches:
-        - 1.x
+        - 2.x


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

More house keeping

# How should this be tested?

Currently when trying to access line by line code coverage you get an error like 
> There was a problem getting the source code from your provider. Unable to show line by line coverage.

For example: https://app.codecov.io/gh/Islandora/Alpaca/commit/59a4acfd249d1bc1c3b3403a6a23e264c2c29b9a/build_dir/islandora-support/src/main/java/ca/islandora/alpaca/support/config/PropertyConfig.java

I think this is because it is trying to use the wrong branch.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
