### PR TITLE
Add full event as base 64 encoded X-Islandora-Event header

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.3.0-SNAPSHOT
+version = 2.4.0-SNAPSHOT

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -112,23 +112,54 @@ public class DerivativeConnector extends RouteBuilder {
             .setHeader(Exchange.HTTP_METHOD, constant("GET"))
             .process(exchange -> {
             final String jsonEvent = exchange.getProperty("event", String.class);
-            if (jsonEvent != null) {
-                final String b64 = java.util.Base64.getEncoder()
-                .encodeToString(jsonEvent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-                exchange.getIn().setHeader("X-Islandora-Event", b64);
-            }
+                if (jsonEvent != null) {
+                    final String b64 = java.util.Base64.getEncoder()
+                    .encodeToString(jsonEvent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                    exchange.getIn().setHeader("X-Islandora-Event", b64);
+                }
             })
-            .setHeader("Accept", simple("${exchangeProperty.eventPojo.attachment.content.mimetype}"))
-            .setHeader("X-Islandora-Args", simple("${exchangeProperty.eventPojo.attachment.content.args}"))
-            .setHeader("Apix-Ldp-Resource", simple("${exchangeProperty.eventPojo.attachment.content.sourceUri}"))
+            .process(exchange -> {
+            final AS2Event event = exchange.getProperty("eventPojo", AS2Event.class);
+                if (event != null && event.getAttachment() != null
+                    && event.getAttachment().getContent() != null) {
+
+                    final var content = event.getAttachment().getContent();
+                    if (content.getMimetype() != null) {
+                        exchange.getIn().setHeader("Accept", content.getMimetype());
+                    }
+                    if (content.getArgs() != null) {
+                        exchange.getIn().setHeader("X-Islandora-Args", content.getArgs());
+                    }
+                    if (content.getSourceUri() != null) {
+                        exchange.getIn().setHeader("Apix-Ldp-Resource", content.getSourceUri());
+                    }
+
+                }
+            })
             .setBody(simple("${null}"))
             .to(outputStream)
 
             // PUT the media.
             .removeHeaders("*", "Authorization", "Content-Type")
-            .setHeader("Content-Location", simple("${exchangeProperty.eventPojo.attachment.content.fileUploadUri}"))
-            .setHeader(Exchange.HTTP_METHOD, constant("PUT"))
-            .toD(config.addHttpOptions("${exchangeProperty.eventPojo.attachment.content.destinationUri}"));
+            .process(exchange -> {
+                final AS2Event event = exchange.getProperty("eventPojo", AS2Event.class);
+                final boolean shouldPut = event != null && event.getAttachment() != null
+                    && event.getAttachment().getContent() != null;
+                exchange.setProperty("shouldPutMedia", shouldPut);
+
+                if (shouldPut) {
+                    final var content = event.getAttachment().getContent();
+                    if (content.getFileUploadUri() != null) {
+                        exchange.getIn().setHeader("Content-Location", content.getFileUploadUri());
+                    }
+                    exchange.getIn().setHeader(Exchange.HTTP_METHOD, "PUT");
+                }
+            })
+            .choice()
+                .when(simple("${exchangeProperty.shouldPutMedia} == true"))
+                    .toD(config.addHttpOptions(
+                        "${exchangeProperty.eventPojo.attachment.content.destinationUri}"))
+            .end();
     }
 
 }

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -111,7 +111,7 @@ public class DerivativeConnector extends RouteBuilder {
             .removeHeaders("*", "Authorization")
             .setHeader(Exchange.HTTP_METHOD, constant("GET"))
             .process(exchange -> {
-            final String jsonEvent = exchange.getProperty("event", String.class);
+                final String jsonEvent = exchange.getProperty("event", String.class);
                 if (jsonEvent != null) {
                     final String b64 = java.util.Base64.getEncoder()
                     .encodeToString(jsonEvent.getBytes(java.nio.charset.StandardCharsets.UTF_8));

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -119,7 +119,7 @@ public class DerivativeConnector extends RouteBuilder {
                 }
             })
             .process(exchange -> {
-            final AS2Event event = exchange.getProperty("eventPojo", AS2Event.class);
+                final AS2Event event = exchange.getProperty("eventPojo", AS2Event.class);
                 if (event != null && event.getAttachment() != null
                     && event.getAttachment().getContent() != null) {
 

--- a/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
+++ b/islandora-connector-derivative/src/main/java/ca/islandora/alpaca/connector/derivative/DerivativeConnector.java
@@ -100,26 +100,35 @@ public class DerivativeConnector extends RouteBuilder {
 
             .log(DEBUG, LOGGER, "Received message on IslandoraConnectorDerivative-" + connectorName)
 
-            // Parse the event into a POJO.
-            .unmarshal().json(JsonLibrary.Jackson, AS2Event.class)
-
-            // Stash the event on the exchange.
+            // Stash the original JSON body on the exchange.
             .setProperty("event").simple("${body}")
+
+            // Parse the event into a POJO for property extraction.
+            .unmarshal().json(JsonLibrary.Jackson, AS2Event.class)
+            .setProperty("eventPojo").simple("${body}")
 
             // Make the Crayfish request.
             .removeHeaders("*", "Authorization")
             .setHeader(Exchange.HTTP_METHOD, constant("GET"))
-            .setHeader("Accept", simple("${exchangeProperty.event.attachment.content.mimetype}"))
-            .setHeader("X-Islandora-Args", simple("${exchangeProperty.event.attachment.content.args}"))
-            .setHeader("Apix-Ldp-Resource", simple("${exchangeProperty.event.attachment.content.sourceUri}"))
+            .process(exchange -> {
+            final String jsonEvent = exchange.getProperty("event", String.class);
+            if (jsonEvent != null) {
+                final String b64 = java.util.Base64.getEncoder()
+                .encodeToString(jsonEvent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                exchange.getIn().setHeader("X-Islandora-Event", b64);
+            }
+            })
+            .setHeader("Accept", simple("${exchangeProperty.eventPojo.attachment.content.mimetype}"))
+            .setHeader("X-Islandora-Args", simple("${exchangeProperty.eventPojo.attachment.content.args}"))
+            .setHeader("Apix-Ldp-Resource", simple("${exchangeProperty.eventPojo.attachment.content.sourceUri}"))
             .setBody(simple("${null}"))
             .to(outputStream)
 
             // PUT the media.
             .removeHeaders("*", "Authorization", "Content-Type")
-            .setHeader("Content-Location", simple("${exchangeProperty.event.attachment.content.fileUploadUri}"))
+            .setHeader("Content-Location", simple("${exchangeProperty.eventPojo.attachment.content.fileUploadUri}"))
             .setHeader(Exchange.HTTP_METHOD, constant("PUT"))
-            .toD(config.addHttpOptions("${exchangeProperty.event.attachment.content.destinationUri}"));
+            .toD(config.addHttpOptions("${exchangeProperty.eventPojo.attachment.content.destinationUri}"));
     }
 
 }


### PR DESCRIPTION
**GitHub Issue**: [Event RFD (0000)](https://github.com/Islandora-Labs/rfds/blob/RFD-0000/0000/README.md?plain=1#L111-L114)

# What does this Pull Request do?

Add the complete event JSON as an `X-Islandora-Event` HTTP header when calling microservices

- Serialize the full event payload to JSON
- Base64 encode if needed to handle special characters
- Include as additional header alongside existing parameters

# How should this be tested?

🤷‍♂️ - throwing this up here for now; but I'm guessing we need to

1. Deploy it
2. Create a microservice that will read out the new header and dump it so we can see that it came through
3. Add an event to the queue for the new service so Alpaca picks it up and shuttles the event along.

The resulting alpaca build is too big for GitHub to permit me to attach it here. So, to build it yourself only using docker (no Java  or Gradle required): `docker run --rm -v "$(pwd):/app" -w /app eclipse-temurin:11  ./gradlew --stacktrace clean build shadowJar --no-daemon`.

The resulting Jar file you need will be @ `islandora-alpaca-app/build/libs/islandora-alpaca-*-all.jar`

# Interested parties
@Islandora/committers, esp @joecorall 
